### PR TITLE
Align to correct version of py-sonic before py2 deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'setuptools',
         'Mopidy >= 1.0',
         'Pykka >= 1.1',
-        'py-sonic',
+        'py-sonic == 0.6.2',
     ],
     entry_points={
         b'mopidy.ext': [


### PR DESCRIPTION
Avoid error of mixing py2 and py3 code, py2 has been depricated in py-sonic from 0.6.2 onwards

This is the error installing from master head with pip
```
pip install https://github.com/loldaves/mopidy-subsonic/archive/master.zip --upgrade
Collecting https://github.com/loldaves/mopidy-subsonic/archive/master.zip
  Downloading https://github.com/loldaves/mopidy-subsonic/archive/master.zip
Requirement already up-to-date: Mopidy>=1.0 in /usr/lib/python2.7/dist-packages (from Mopidy-Subsonic==1.0.0)
Requirement already up-to-date: Pykka>=1.1 in /usr/lib/python2.7/dist-packages (from Mopidy-Subsonic==1.0.0)
Collecting py-sonic (from Mopidy-Subsonic==1.0.0)
  Using cached https://files.pythonhosted.org/packages/e7/ae/4a48ca9010d8f69714f01a223de66949cbe52c233d231479dcaabb4df1a7/py-sonic-0.7.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-5pbOUO/py-sonic/setup.py", line 21, in <module>
        from libsonic import __version__ as version
      File "libsonic/__init__.py", line 30, in <module>
        from .connection import *
      File "libsonic/connection.py", line 21, in <module>
        import urllib.request
    ImportError: No module named request
    
    ----------------------------------------
```